### PR TITLE
Update plugin version to 2.4 and add new cvars

### DIFF
--- a/_AutoTakeOver/scripting/_AutoTakeOver.sp
+++ b/_AutoTakeOver/scripting/_AutoTakeOver.sp
@@ -78,7 +78,7 @@ public void OnPluginStart()
 	g_hCvarTakeOverOnBotSpawnSpectator.AddChangeHook(ConVarChanged_Cvars);
 	g_hCvarTakeOverOnJoinServer.AddChangeHook(ConVarChanged_Cvars);
 
-	RegAdminCmd("sm_printbestavailablebots", CmdPrintBestAvailableBots, ADMFLAG_ROOT, "Lists all available survivor bots, ordered from best to worst.");
+	RegAdminCmd("sm_printbestavailablebots", CmdPrintBestAvailableBots, ADMFLAG_ROOT, "Lists all available survivor bots, ordered from best to worst. Usage: sm_printbestavailablebots [top]");
 }
 
 void ConVarGameMode(ConVar convar, const char[] oldValue, const char[] newValue)


### PR DESCRIPTION
Added "AutoTakeOver_take_over_random" cvar to control if the selected bot should be randomized or by best available (not incap and highest HP) Removed some extra spaces
Added Z flag command to "debug" the best bots by ranking Renamed the AutoTakeOver_take_over_UponDeath cvar description