### PR TITLE
l4d2_skill_detect: Fix warning

### DIFF
--- a/l4d2_skill_detect/scripting/l4d2_skill_detect.sp
+++ b/l4d2_skill_detect/scripting/l4d2_skill_detect.sp
@@ -2720,8 +2720,8 @@ public Action: Event_TonguePullStopped (Handle:event, const String:name[], bool:
 			ZC_SMOKER,
 			(g_fPinTime[smoker][1] > 0.0) ? ( GetEngineTime() - g_fPinTime[smoker][1]) : -1.0,
 			( GetEngineTime() - g_fPinTime[smoker][0]),
-			bool:( reason != CUT_SLASH && reason != CUT_KILL, 
-			false )
+			bool:( reason != CUT_SLASH && reason != CUT_KILL ), 
+			false
 		);
 	
 	if ( attacker == victim )
@@ -2811,8 +2811,8 @@ public Action: Event_ChokeStop (Handle:event, const String:name[], bool:dontBroa
 			ZC_SMOKER,
 			(g_fPinTime[smoker][1] > 0.0) ? ( GetEngineTime() - g_fPinTime[smoker][1]) : -1.0,
 			( GetEngineTime() - g_fPinTime[smoker][0]),
-			bool:( reason != CUT_SLASH && reason != CUT_KILL
-			, false )
+			bool:( reason != CUT_SLASH && reason != CUT_KILL ),
+			false
 		);
 
 	g_bSmokerClearCheck[smoker] = false;


### PR DESCRIPTION
## Summary

- Fixed an issue in `Event_TonguePullStopped` and `Event_ChokeStop` where a comma inside the `bool:()` cast was interpreted as a comma operator when calling `HandleClear`
- The condition (`reason != CUT_SLASH && reason != CUT_KILL`) was being discarded, causing `bWithShove` to always receive `false`

## Changes

Moved the closing parenthesis of the `bool:()` cast before the comma so that the condition is correctly passed as the `bWithShove` argument and `false` is passed as the headshot argument.