### PR TITLE
LMC_BW: Fix glow flashing always enabled when LMC is unavailable

### DIFF
--- a/LMC_Black_and_White_Notifier/scripting/LMC_Black_and_White_Notifier.sp
+++ b/LMC_Black_and_White_Notifier/scripting/LMC_Black_and_White_Notifier.sp
@@ -222,7 +222,6 @@ void NextFrame_ReviveSuccess(int client)
 			SetEntProp(client, Prop_Send, "m_iGlowType", 3);
 			SetEntProp(client, Prop_Send, "m_glowColorOverride", g_iGlowColour);
 			SetEntProp(client, Prop_Send, "m_nGlowRange", g_iGlowRange);
-			SetEntProp(client, Prop_Send, "m_bFlashing", 1);
 			if(g_bGlowFlash) SetEntProp(client, Prop_Send, "m_bFlashing", 1);
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes a bug where m_bFlashing was always enabled regardless of the lmc_blackandwhite_glowflash cvar in the non-LMC branch of NextFrame_ReviveSuccess.

## Problem

The branch contained two consecutive SetEntProp calls for the same property:
```sourcepawn
SetEntProp(client, Prop_Send, "m_bFlashing", 1);
if(g_bGlowFlash) SetEntProp(client, Prop_Send, "m_bFlashing", 1);
```
Since the first line unconditionally sets flashing to 1, the g_bGlowFlash check on the second line became meaningless. As a result, on servers without LMC installed, the lmc_blackandwhite_glowflash 0 setting was ignored and the flashing effect was always applied to survivors in the black & white state.

## Fix
Removed the duplicate first line that bypassed the cvar check. The subsequent `if(g_bGlowFlash)` line now controls flashing based on the cvar value as intended.